### PR TITLE
Fix #24 by changing production build filenames

### DIFF
--- a/WebContent/index.html
+++ b/WebContent/index.html
@@ -13,7 +13,6 @@
     <base href="/">
 
     <link rel="icon" href="img/favicon.ico" size="16x16 32x32 48x48 64x64" type="image/vnd.microsoft.icon">
-    <link href="main.min.css" rel="stylesheet">
     <link href="main.css" rel="stylesheet">
 
     <script>
@@ -25,9 +24,7 @@
       ga('create', 'UA-82900227-4', 'auto');
     </script>
 
-    <script src="polyfills.min.js" defer></script>
     <script src="polyfills.js" defer></script>
-    <script src="main.min.js" defer></script>
     <script src="main.js" defer></script>
 
     <base href="/"/>

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -7,7 +7,7 @@ let stylelint = require('stylelint');
 
 // PostCSS Input and Output Path
 const INPUT_PATH = 'WebContent/main.css';
-const OUTPUT_PATH = PRODUCTION_MODE ? 'dist/main.min.css' : 'dist/main.css';
+const OUTPUT_PATH = 'dist/main.css';
 
 // Target Browsers
 const TARGET_BROWSERS = [

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -36,7 +36,7 @@ if (TEST_MODE) {
 
 if (!TEST_MODE) {
     const OUTPUT_DIR = PRODUCTION_MODE ? 'dist' : 'dist',
-        OUTPUT_BASENAME = PRODUCTION_MODE ? 'main.min' : 'main';
+        OUTPUT_BASENAME = 'main';
 
     WEBPACK_CONFIG.entry = {
         polyfills: [
@@ -69,7 +69,7 @@ if (PRODUCTION_MODE) {
     WEBPACK_CONFIG.plugins.push(
         new webpack.optimize.CommonsChunkPlugin({
             name: 'polyfills',
-            filename: 'polyfills.min.js',
+            filename: 'polyfills.js',
             minChunks: Infinity
         }),
         new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
Was causing 404 errors which took multiple seconds to resolve on testing.

This fix simply renames the output build file's names to be the same as the ones used in development, and removing the *.min.* references in index.html. If this is undesirable, we can look for alternative solutions.