### PR TITLE
Add npm module caching on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "node"
+cache:
+  directories:
+    - node_modules
 install:
   - npm install
 script:


### PR DESCRIPTION
Speed up TravisCI builds by caching the npm modules used.