### PR TITLE
Remove login requirement on about, change home URL

### DIFF
--- a/WebContent/js/app.js
+++ b/WebContent/js/app.js
@@ -49,14 +49,14 @@ app.config(['$stateProvider', '$urlRouterProvider', '$locationProvider', '$httpP
     // State configuration
     $stateProvider
       .state('home', {
-        url: '/home',
+        url: '/',
         templateUrl: 'partials/home.html',
         requireLogin: false
       })
       .state('about', {
         url: '/about',
         templateUrl: 'partials/about.html',
-        requireLogin: true
+        requireLogin: false
       })
       .state('login', {
         url: '/login',


### PR DESCRIPTION
The About page required login for whatever reason. Removed this requirement. I blame @LordAlfredo.  
Changed Home URL to be "/" instead of "/home" as is standard.