### PR TITLE
Fix wiki link hijacking

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -50,7 +50,7 @@
               <li data-ng-class="{active: $state.includes('projects')}"><a data-ui-sref="projects.list">Projects</a></li>
               <li data-ng-show="canManagePermissions" data-ng-class="{active: $state.includes('admin.permissions')}"><a data-ui-sref="admin">Permissions</a></li>
               <li data-ng-class="{active: $state.includes('about')}"><a data-ui-sref="about">About</a></li>
-              <li data-ng-class="{active: $state.includes('wiki')}"><a href="/wiki">Wiki</a></li>
+              <li data-ng-class="{active: $state.includes('wiki')}"><a href="/wiki" target="_self">Wiki</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right" data-ng-controller="LoginNavCtrl">
               <li data-ng-show="!isLoggedIn"><a data-ui-sref="login">Login</a></li>


### PR DESCRIPTION
Explanation: $location hijacks any link unless it follows any one of three rules (and is well documented: https://docs.angularjs.org/guide/$location)
* The target attribute is set to "_self"
* The link is not on the same domain.
* The route doesn't use the same base path as the angular app.

Since the wiki link prior to this doesn't use either of the latter two, the only way to force a full page reload in these cases is via the first. This will need to be done for every link we make from the main site to the wiki in the future.

This should still work in a dev environment, though it causes a full page reload before rerouting to the "/wiki" placeholder page.