### PR TITLE
Keep URLs on 404s

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -67,8 +67,6 @@ app.config(['$stateProvider', '$urlRouterProvider', '$locationProvider', '$httpP
     $translateProvider.fallbackLanguage('en');
     $translateProvider.useSanitizeValueStrategy('escape');
 
-    $urlRouterProvider.otherwise('/404');
-
     // State configuration
     $stateProvider
       .state('home', {
@@ -214,10 +212,15 @@ app.config(['$stateProvider', '$urlRouterProvider', '$locationProvider', '$httpP
         requireLogin: false
       })
       .state('404', {
-        url: '/404',
         templateUrl: 'partials/404.html',
         requireLogin:false
       })
+
+      $urlRouterProvider.otherwise(function($injector, $location) {
+        var state = $injector.get('$state');
+        state.go('404');
+        return $location.path();
+      });
 
       // Prevent unauthorized requests to restricted pages & trigger login
       $httpProvider.interceptors.push(['$timeout', '$q', '$injector',


### PR DESCRIPTION
Previously the site would default to '/404' on a failed route. This should allow it to keep the URL while displaying a 404 page.