### PR TITLE
Wiki Frontend Authentication

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -339,6 +339,8 @@ app.run(['$rootScope', '$state', 'AuthService', 'ngMeta',
           if (toState.name == 'logout') {
             AuthService.logout();
             $state.go('login');
+          } else if (toState.name == 'login') {
+            $location.search('redirect_uri', fromState.name);
           }
         });
     });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -322,9 +322,14 @@ app.config(['$stateProvider', '$urlRouterProvider', '$locationProvider', '$httpP
     }
 ]);
 
-app.run(['$rootScope', '$state', 'AuthService', 'ngMeta',
-  function ($rootScope, $state, AuthService, ngMeta) {
+app.run(['$rootScope', '$state', 'AuthService', 'ngMeta', '$location',
+  function ($rootScope, $state, AuthService, ngMeta, $location) {
     ngMeta.init();
+    $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams) {
+      if(toState.name == 'login' && fromState.name !== '') {
+        $location.search('redirect_uri', fromState.name);
+      }
+    });
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
       AuthService.getUserStatus()
         .then(function() {
@@ -339,8 +344,6 @@ app.run(['$rootScope', '$state', 'AuthService', 'ngMeta',
           if (toState.name == 'logout') {
             AuthService.logout();
             $state.go('login');
-          } else if (toState.name == 'login') {
-            $location.search('redirect_uri', fromState.name);
           }
         });
     });

--- a/src/js/auth/controllers.js
+++ b/src/js/auth/controllers.js
@@ -9,15 +9,19 @@ appControllers.controller('LoginNavCtrl', ['$scope', 'AuthService',
 }]);
 
 
-appControllers.controller('LoginCtrl', ['$scope', '$state', 'AuthService',
-  function($scope, $state, AuthService) {
+appControllers.controller('LoginCtrl', ['$scope', '$state', 'AuthService', '$routeParams'
+  function($scope, $state, AuthService, $routeParams) {
     $scope.login = function() {
       $scope.error = false;
       $scope.disabled = true;
 
       AuthService.login($scope.loginForm.username, $scope.loginForm.password, $scope.loginForm.remember_me)
         .then(function() {
-          $state.go('home');
+          if($routeParams.redirect_uri !=== '') {
+            $state.go($routeParams.redirect_uri)
+          } else {
+            $state.go('home');
+          }
           $scope.disabled = false;
           $scope.loginForm = {};
         })

--- a/src/js/auth/controllers.js
+++ b/src/js/auth/controllers.js
@@ -9,16 +9,17 @@ appControllers.controller('LoginNavCtrl', ['$scope', 'AuthService',
 }]);
 
 
-appControllers.controller('LoginCtrl', ['$scope', '$state', 'AuthService', '$routeParams',
-  function($scope, $state, AuthService, $routeParams) {
+appControllers.controller('LoginCtrl', ['$scope', '$state', 'AuthService', '$location',
+  function($scope, $state, AuthService, $location) {
     $scope.login = function() {
       $scope.error = false;
       $scope.disabled = true;
 
       AuthService.login($scope.loginForm.username, $scope.loginForm.password, $scope.loginForm.remember_me)
         .then(function() {
-          if($routeParams.redirect_uri !== '') {
-            $state.go($routeParams.redirect_uri)
+          var redirect = $location.search()['redirect_uri'];
+          if(redirect !== '') {
+            $state.go(redirect);
           } else {
             $state.go('home');
           }

--- a/src/js/auth/controllers.js
+++ b/src/js/auth/controllers.js
@@ -9,7 +9,7 @@ appControllers.controller('LoginNavCtrl', ['$scope', 'AuthService',
 }]);
 
 
-appControllers.controller('LoginCtrl', ['$scope', '$state', 'AuthService', '$routeParams'
+appControllers.controller('LoginCtrl', ['$scope', '$state', 'AuthService', '$routeParams',
   function($scope, $state, AuthService, $routeParams) {
     $scope.login = function() {
       $scope.error = false;
@@ -17,7 +17,7 @@ appControllers.controller('LoginCtrl', ['$scope', '$state', 'AuthService', '$rou
 
       AuthService.login($scope.loginForm.username, $scope.loginForm.password, $scope.loginForm.remember_me)
         .then(function() {
-          if($routeParams.redirect_uri !=== '') {
+          if($routeParams.redirect_uri !== '') {
             $state.go($routeParams.redirect_uri)
           } else {
             $state.go('home');

--- a/src/js/auth/services.js
+++ b/src/js/auth/services.js
@@ -6,19 +6,25 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
     var permissions = null; // We cache this for performance.  The backend will still do a final check that can override this.
 
     function getSessionId() {
-      return $cookies.get('htsessionid');
+      return $cookies.get('htlogin').split("#")[3];
     }
 
-    function setSessionId(sessionId, expiration) {
+    function getWikiId(username) {
+      //TODO(james7132): Implement
+      return username;
+    }
+
+    function setCookie(sessionId, username, email, expiration) {
       let params = {};
-      if(expiration != null){
+      if(expiration != null) {
         params['expires'] = new Date(expiration);
       }
-      $cookies.put('htsessionid', sessionId, params);
+      let wiki_id = getWikiId(username);
+      $cookies.put('htlogin', wiki_id + "#" + email + "#" + username + "#" session_id, params);
     }
 
-    function clearSessionId(){
-      $cookies.remove('htsessionid');
+    function clearSessionId() {
+      $cookies.remove('htlogin');
     }
 
     function isLoggedIn() {
@@ -84,7 +90,10 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
       HttpService.post('auth/login', null, {username: username, password: password, remember_me: remember_me})
         .success(function(data, status) {
           if(status === 200 && data.session_id != null) {
-            setSessionId(data.session_id, data.expiration);
+            setSessionId(data.session_id,
+                data.username,
+                data.email,
+                data.expiration);
             permissions = data.permissions;
             $rootScope.user = true;
             deferred.resolve();

--- a/src/js/auth/services.js
+++ b/src/js/auth/services.js
@@ -6,7 +6,10 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
     var permissions = null; // We cache this for performance.  The backend will still do a final check that can override this.
 
     function getSessionId() {
-      return $cookies.get('htlogin').split("#")[3];
+      let cookie = $cookies.get('htlogin');
+      if (typeof cookie != 'undefined') {
+        return cookie.split("#")[3];
+      }
     }
 
     function getWikiId(username) {

--- a/src/js/auth/services.js
+++ b/src/js/auth/services.js
@@ -19,8 +19,8 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
       if(expiration != null) {
         params['expires'] = new Date(expiration);
       }
-      let wiki_id = getWikiId(username);
-      $cookies.put('htlogin', wiki_id + "#" + email + "#" + username + "#" session_id, params);
+      let wikiId= getWikiId(username);
+      $cookies.put('htlogin', wikiId+ "#" + email + "#" + username + "#" + sessionId, params);
     }
 
     function clearSessionId() {
@@ -90,7 +90,7 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
       HttpService.post('auth/login', null, {username: username, password: password, remember_me: remember_me})
         .success(function(data, status) {
           if(status === 200 && data.session_id != null) {
-            setSessionId(data.session_id,
+            setCookie(data.session_id,
                 data.username,
                 data.email,
                 data.expiration);

--- a/src/js/auth/services.js
+++ b/src/js/auth/services.js
@@ -13,8 +13,9 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
     }
 
     function getWikiId(username) {
-      //TODO(james7132): Implement
-      return username;
+      return username.replace(/(\w)(\w*)[^\w]*/g, function(g0,g1,g2){
+        return g1.toUpperCase() + g2.toLowerCase();
+      })
     }
 
     function setCookie(sessionId, username, email, expiration) {
@@ -221,6 +222,7 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
       isLoggedIn: isLoggedIn,
       allowAccess: allowAccess,
       getUserStatus: getUserStatus,
+      getWikiId: getWikiId,
       login: login,
       logout: logout,
       register: register,

--- a/src/js/auth/services.spec.js
+++ b/src/js/auth/services.spec.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+import App from '../app.js';
+import './services.js';
+
+beforeEach(angular.mock.module(App));
+
+describe("AuthService", function() {
+  var authService;
+  beforeEach(angular.mock.inject(function(AuthService) {
+    authService = AuthService;
+  }));
+
+  it("should produce valid wiki names", function() {
+    expect(authService.getWikiId("jane")).toEqual("Jane");
+    expect(authService.getWikiId("John")).toEqual("John");
+    expect(authService.getWikiId("alIce aCC")).toEqual("AliceAcc");
+    expect(authService.getWikiId("bob abc")).toEqual("BobAbc");
+    expect(authService.getWikiId("Xmd-bca")).toEqual("XmdBca");
+    expect(authService.getWikiId("dAnIEl231")).toEqual("Daniel231");
+  });
+
+});


### PR DESCRIPTION
* Added a redirect_uri query parameter on login page to tell where to redirect the user post-login
* Changed login token to "wiki_name#email#username#session_id"

This allows the wiki to link to the login page on the main site, have the user log in, and save a cookie that is readable on the wiki's side.

This change depends on the wiki_auth implementation on the backend, and should not be merged until that is merged and ready.