### PR TITLE
Fix login errors not being displayed properly

### DIFF
--- a/src/js/auth/services.js
+++ b/src/js/auth/services.js
@@ -110,7 +110,7 @@ appServices.factory('AuthService', ['$rootScope', '$q', '$timeout', '$cookies', 
         .error(function(data) {
           permissions = null;
           $rootScope.user = false;
-          deferred.reject();
+          deferred.reject(data);
         });
 
       return deferred.promise;


### PR DESCRIPTION
Login errors were not being passed to the controller on failure to login: showing nothing to the user.