### PR TITLE
Issues/63

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -3,6 +3,12 @@ const PRODUCTION_MODE = (process.env.NODE_ENV === 'production');
 const TEST_MODE = (process.env.NODE_ENV === 'test');
 const DEVELOPMENT_MODE = (!PRODUCTION_MODE && !TEST_MODE);
 
+// These should be full URL's, containing the protocol, hostname, and port
+// number. In particular, the frontend will do a check to ensure that
+// the protocol is specified.
+const PRODUCTION_API_URL = 'https://houraiteahouse.net:92';
+const DEVELOPMENT_API_URL = 'http://localhost:5000';
+
 // Imports
 let path = require('path');
 let webpack = require('webpack');
@@ -31,6 +37,13 @@ const WEBPACK_CONFIG = {
 
 // Customize Webpack Config
 if (TEST_MODE) {
+    WEBPACK_CONFIG.module.preLoaders.push({
+        test: /\.js$/,
+        loader: 'preprocess-loader',
+        query: { TEST_MODE },
+        include: new RegExp(ENTRY_DIR),
+        exclude: /node_modules/
+    });
     WEBPACK_CONFIG.devtool = 'inline-source-map';
 }
 
@@ -58,7 +71,7 @@ if (DEVELOPMENT_MODE) {
     WEBPACK_CONFIG.module.preLoaders.push({
         test: /\.js$/,
         loader: 'preprocess-loader',
-        query: { DEVELOPMENT_MODE, DEVELOPMENT_URL: 'http://localhost:5000' },
+        query: { DEVELOPMENT_MODE, DEVELOPMENT_API_URL },
         include: new RegExp(ENTRY_DIR),
         exclude: /node_modules/
     });
@@ -76,7 +89,7 @@ if (PRODUCTION_MODE) {
     WEBPACK_CONFIG.module.preLoaders.push({
         test: /\.js$/,
         loader: 'preprocess-loader',
-        query: { PRODUCTION_MODE, PRODUCTION_URL: 'https://houraiteahouse.net:92' },
+        query: { PRODUCTION_MODE, PRODUCTION_API_URL },
         include: new RegExp(ENTRY_DIR),
         exclude: /node_modules/
     });

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -55,6 +55,13 @@ if (!TEST_MODE) {
 if (DEVELOPMENT_MODE) {
     WEBPACK_CONFIG.output.sourceMapFilename = '[file].map';
     WEBPACK_CONFIG.output.devtoolModuleFilenameTemplate = '[resource-path]';
+    WEBPACK_CONFIG.module.preLoaders.push({
+        test: /\.js$/,
+        loader: 'preprocess-loader',
+        query: { DEVELOPMENT_MODE, DEVELOPMENT_URL: 'http://localhost:5000' },
+        include: new RegExp(ENTRY_DIR),
+        exclude: /node_modules/
+    });
     WEBPACK_CONFIG.plugins.push(
         new webpack.optimize.CommonsChunkPlugin({
             name: 'polyfills',
@@ -66,6 +73,13 @@ if (DEVELOPMENT_MODE) {
 }
 
 if (PRODUCTION_MODE) {
+    WEBPACK_CONFIG.module.preLoaders.push({
+        test: /\.js$/,
+        loader: 'preprocess-loader',
+        query: { PRODUCTION_MODE, PRODUCTION_URL: 'https://houraiteahouse.net:92' },
+        include: new RegExp(ENTRY_DIR),
+        exclude: /node_modules/
+    });
     WEBPACK_CONFIG.plugins.push(
         new webpack.optimize.CommonsChunkPlugin({
             name: 'polyfills',

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "postcss-cssnext": "~2.8.x",
     "postcss-import": "~8.1.x",
     "postcss-reporter": "~1.4.x",
+    "preprocess-loader": "~0.2.x",
     "stylelint": "~7.5.x",
     "stylelint-config-standard": "~14.0.x",
     "webpack": "~1.13.x"

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -43,14 +43,21 @@ var app = angular.module('houraiteahouse', [
 
 var options = (function() {
   var base_url;
-  if(window.location.hostname.includes('localhost')) {
-    // Local testing backend
-    base_url = "http://localhost:5000";
-  } else {
-    // Produciton backend
-    base_url = "https://houraiteahouse.net:92";
+
+  // @ifdef DEVELOPMENT_MODE
+  // Local testing backend
+  base_url = "/* @echo DEVELOPMENT_URL */";
+  // @endif
+
+  // @ifdef PRODUCTION_MODE
+  // Production backend
+  base_url = "/* @echo PRODUCTION_URL */";
+  // @endif
+
+  if (!base_url) {
+    throw new Error('API url is not configured!!!');
   }
-  console.log(base_url);
+
   return {
     "api":{
       "base_url": base_url

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -46,14 +46,22 @@ var options = (function() {
 
   // @ifdef DEVELOPMENT_MODE
   // Local testing backend
-  base_url = "/* @echo DEVELOPMENT_URL */";
+  base_url = "/* @echo DEVELOPMENT_API_URL */";
   // @endif
 
   // @ifdef PRODUCTION_MODE
   // Production backend
-  base_url = "/* @echo PRODUCTION_URL */";
+  base_url = "/* @echo PRODUCTION_API_URL */";
   // @endif
 
+  // @ifdef TEST_MODE
+  // Unit testing mock api path
+  base_url = '/api';
+  // @endif
+
+  // @ifndef TEST_MODE
+  // Do some last minute checking to ensure that the URL
+  // was preprocessed correctly, and that it is valid
   if (!base_url) {
     throw new Error('API URL is not defined!!!');
   }
@@ -61,6 +69,7 @@ var options = (function() {
   if (!base_url.match(/^(?:http|https):\/\/.+$/)) {
     throw new Error('API URL is not valid!');
   }
+  // @endif
 
   return {
     "api":{

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -55,7 +55,11 @@ var options = (function() {
   // @endif
 
   if (!base_url) {
-    throw new Error('API url is not configured!!!');
+    throw new Error('API URL is not defined!!!');
+  }
+
+  if (!base_url.match(/^(?:http|https):\/\/.+$/)) {
+    throw new Error('API URL is not valid!');
   }
 
   return {

--- a/src/js/app.spec.js
+++ b/src/js/app.spec.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import App from './app.js';
+import App, { options } from './app.js';
 
 beforeEach(angular.mock.module(App));
 
@@ -7,5 +7,10 @@ describe('App Module', () => {
     // dummy test
     it('should be called houraiteahouse', () => {
         expect(App).toBe('houraiteahouse');
+    });
+
+    // Verify that build system preprocessing is working correctly
+    it('should have a base API URL.', () => {
+        expect(options.api.base_url).toBe('/api');
     });
 });


### PR DESCRIPTION
Build time preprocessing for determining the API base URL. Closes #63 .

Testing notes:
1) Run `build-all-development` and ensure that the app attempts to hit localhost:5000 for API requests
2) Run `build-all-production` and ensure that the app attempts to hit houraiteahouse.net:92 for API requests
3) Run `test-unit` and ensure that the unit tests pass
4) BONUS: look in the generated JavaScript for both development and production builds and note that any indication of build time processing is not present in the final output.